### PR TITLE
Added property for opencover report path.

### DIFF
--- a/src/Cake.Sonar/SonarBeginSettings.cs
+++ b/src/Cake.Sonar/SonarBeginSettings.cs
@@ -29,6 +29,9 @@
         [Argument("/d:sonar.cs.dotcover.reportsPaths=")]
         public string DotCoverReportsPath { get; set; }
 
+        [Argument("/d:sonar.cs.opencover.reportsPaths=")]
+        public string OpenCoverReportsPath { get; set; }
+
         public bool Verbose { get; set; }
     }
 }


### PR DESCRIPTION
Adds support for OpenCover according to documentation here: http://docs.sonarqube.org/pages/viewpage.action?pageId=6389770#CodeCoverageResultsImport(C#,VB.NET)-OpenCover