### PR TITLE
Added SecretArgumentAttribute for sensitive configuration.

### DIFF
--- a/src/Cake.Sonar/Attributes/ArgumentAttribute.cs
+++ b/src/Cake.Sonar/Attributes/ArgumentAttribute.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
 
-namespace Cake.Sonar
+namespace Cake.Sonar.Attributes
 {
     [AttributeUsage(AttributeTargets.Property)]
     public class ArgumentAttribute : Attribute 

--- a/src/Cake.Sonar/Attributes/SecretArgumentAttribute.cs
+++ b/src/Cake.Sonar/Attributes/SecretArgumentAttribute.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Cake.Sonar.Attributes
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class SecretArgumentAttribute : Attribute
+    {
+        public string Name { get; set; }
+
+        public SecretArgumentAttribute(string name)
+        {
+            Name = name;
+        }
+    }
+}

--- a/src/Cake.Sonar/Cake.Sonar.csproj
+++ b/src/Cake.Sonar/Cake.Sonar.csproj
@@ -44,7 +44,8 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="ArgumentAttribute.cs" />
+    <Compile Include="Attributes\ArgumentAttribute.cs" />
+    <Compile Include="Attributes\SecretArgumentAttribute.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SonarBeginSettings.cs" />
     <Compile Include="SonarCake.cs" />

--- a/src/Cake.Sonar/SonarBeginSettings.cs
+++ b/src/Cake.Sonar/SonarBeginSettings.cs
@@ -1,4 +1,6 @@
-﻿namespace Cake.Sonar
+﻿using Cake.Sonar.Attributes;
+
+namespace Cake.Sonar
 {
     public class SonarBeginSettings
     {
@@ -8,7 +10,7 @@
         [Argument("/d:sonar.login=")]
         public string Login { get; set; }
 
-        [Argument("/d:sonar.password=")]
+        [SecretArgument("/d:sonar.password=")]
         public string Password { get; set; }
 
         [Argument("/k:")]

--- a/src/Cake.Sonar/SonarEndSettings.cs
+++ b/src/Cake.Sonar/SonarEndSettings.cs
@@ -1,4 +1,6 @@
-﻿namespace Cake.Sonar
+﻿using Cake.Sonar.Attributes;
+
+namespace Cake.Sonar
 {
     public class SonarEndSettings
     {
@@ -6,7 +8,7 @@
         [Argument("/d:sonar.login=")]
         public string Login { get; set; }
 
-        [Argument("/d:sonar.password=")]
+        [SecretArgument("/d:sonar.password=")]
         public string Password { get; set; }
     }
 }


### PR DESCRIPTION
This commit adds a SecretArgumentAttribute for sensitive information in settings like passwords etc. By using this new attribute sensitive configuration will not appear as plain text in logs but be replaced with [redacted] as placeholder.