### PR TITLE
Add target lib/net45 when creating nuget package

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -86,8 +86,8 @@ Task("Pack")
                                 Symbols                 = false,
                                 NoPackageAnalysis       = true,
                                 Files                   = new [] {
-                                                                     new NuSpecContent {Source = "Cake.Sonar.dll" },
-																	 new NuSpecContent {Source = "Cake.Sonar.xml" }
+                                                                     new NuSpecContent {Source = "Cake.Sonar.dll", Target = "lib/net45" },
+                                                                     new NuSpecContent {Source = "Cake.Sonar.xml", Target = "lib/net45" }
                                                                   },
                                 BasePath                = "./src/Cake.Sonar/bin/release",
                                 OutputDirectory         = "./nuget"


### PR DESCRIPTION
Without a target, Cake.Sonar.dll remains at the root of the package
prevent it from being reference in any project (Error  Could not install
package 'Cake.Sonar 0.2.1'. You are trying to install this package into
a project that targets '.NETFramework,Version=v4.5', but the package
does not contain any assembly references or content files that are
compatible with that framework. For more information, contact the
package author. )