### PR TITLE
Fix parameters quoting

### DIFF
--- a/src/Cake.Sonar/SonarSettings.cs
+++ b/src/Cake.Sonar/SonarSettings.cs
@@ -58,7 +58,9 @@ namespace Cake.Sonar
                 if (value != null)
                 {
                     var filePath = value as FilePath;
-                    var stringValue = filePath != null ? filePath.MakeAbsolute(environment).FullPath.Quote() : pi.GetValue(s).ToString();
+                    var stringValue = filePath != null 
+                        ? filePath.MakeAbsolute(environment).FullPath.Quote() 
+                        : pi.GetValue(s).ToString().Quote();
                     builder.Append($"{attr.Name}{stringValue}");
                 }
             }


### PR DESCRIPTION
I can purpose a #33 fix.

It works perfect if I run tool with quoted parameters like this:

.\tools\MSBuild.SonarQube.Runner.Tool\tools\MSBuild.SonarQube.Runner.exe end /d:sonar.host.url="https://sonarcloud.io/" /k:"Crawler.Example" /n:"Crawler Example" /d:sonar.login="d4f9.......57a" /d:sonar.verbose=true