### PR TITLE
Upgrade to Cake 0.26

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -91,8 +91,8 @@ Task("Pack")
                                 Files                   = new [] {
 																	 new NuSpecContent {Source = "net46/Cake.Sonar.dll", Target = "lib/net46" },
                                                                      new NuSpecContent {Source = "net46/Cake.Sonar.xml", Target = "lib/net46" },
-																	 new NuSpecContent {Source = "netstandard1.6/Cake.Sonar.dll", Target = "lib/netstandard1.6" },
-                                                                     new NuSpecContent {Source = "netstandard1.6/Cake.Sonar.xml", Target = "lib/netstandard1.6" }
+																	 new NuSpecContent {Source = "netstandard2.0/Cake.Sonar.dll", Target = "lib/netstandard2.0" },
+                                                                     new NuSpecContent {Source = "netstandard2.0/Cake.Sonar.xml", Target = "lib/netstandard2.0" }
                                                                   },
                                 BasePath                = "./src/Cake.Sonar/bin/release",
                                 OutputDirectory         = "./nuget"

--- a/src/Cake.Sonar.Test/Cake.Sonar.Test.csproj
+++ b/src/Cake.Sonar.Test/Cake.Sonar.Test.csproj
@@ -9,8 +9,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="Cake.Common" Version="0.25.0" />
-    <PackageReference Include="Cake.Core" Version="0.25.0" />
+    <PackageReference Include="Cake.Common" Version="0.26.0" />
+    <PackageReference Include="Cake.Core" Version="0.26.0" />
     <PackageReference Include="xunit.runner.console" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
   </ItemGroup>

--- a/src/Cake.Sonar/Cake.Sonar.csproj
+++ b/src/Cake.Sonar/Cake.Sonar.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
+    <TargetFrameworks>net46;netstandard2.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Common" Version="0.25.0" />
-    <PackageReference Include="Cake.Core" Version="0.25.0" />
+    <PackageReference Include="Cake.Common" Version="0.26.0" />
+    <PackageReference Include="Cake.Core" Version="0.26.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Remove="Attributes\SecretArgumentAttribute.cs" />


### PR DESCRIPTION
This fixes the issue #44 

The Cake.Core 0.26 needs netstandard 2.0 instead 1.6, so I upgraded the netstandard version too. I keep the net46

I ran the tests, and tested locally a Sonar analysis with the compiled result of this changes. It worked fine without addind the skip verification flag