### PR TITLE
Add support to new SonarScanner MSBuild executable.

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -25,7 +25,7 @@ var isMasterBranch = System.String.Equals("master", branchName, System.StringCom
 // VERSION
 ///////////////////////////////////////////////////////////////////////////////
 
-var version = "1.0.5";
+var version = "1.0.6";
 var semVersion = local ? version : (version + string.Concat("+", buildNumber));
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/Cake.Sonar/SonarRunner.cs
+++ b/src/Cake.Sonar/SonarRunner.cs
@@ -24,7 +24,7 @@ namespace Cake.Sonar
 
         protected override IEnumerable<string> GetToolExecutableNames()
         {
-            return new[] {"SonarQube.Scanner.MSBuild.exe"};
+            return new[] {"SonarScanner.MSBuild.exe", "SonarQube.Scanner.MSBuild.exe"};
         }
 
         public void Run(SonarSettings settings)


### PR DESCRIPTION
The new version of SonarScanner for MSBuild 4.1 giving us this warning message.

```
WARNING: ------------------------------------------------------------------------
This executable is deprecated and may be removed in next major version of the SonarScanner for MSBuild. Please use 'SonarScanner.MSBuild.exe' instead.
------------------------------------------------------------------------
```

So, I added SonarScanner.MSBuild.exe executable support. I think it's ready for the new major version of the SonarScanner now. :)