### PR TITLE
Import into SonarQube issues generated by TSLint

### DIFF
--- a/src/Cake.Sonar.Test/JavascriptCoverageArgumentBuilderTest.cs
+++ b/src/Cake.Sonar.Test/JavascriptCoverageArgumentBuilderTest.cs
@@ -6,7 +6,7 @@ namespace Cake.Sonar.Test
     public class JavascriptCoverageArgumentBuilderTest
     {
         [Fact]
-        public void CoverageExclussionsTest()
+        public void JavascriptCoverageTest()
         {
             var beginSettings = new SonarBeginSettings
             {

--- a/src/Cake.Sonar.Test/TSLintReportArgumentBuilderTest.cs
+++ b/src/Cake.Sonar.Test/TSLintReportArgumentBuilderTest.cs
@@ -1,0 +1,31 @@
+﻿namespace Cake.Sonar.Test
+{
+    using System;
+    using Xunit;
+
+    public class TSLintReportArgumentBuilderTest
+    {
+        [Fact]
+        public void TSLintReportTest()
+        {
+            var beginSettings = new SonarBeginSettings
+            {
+                Login = "tom",
+                Password = "god",
+                Url = "http://sonarqube.com:9000",
+                TSLintReportPaths = "tslint-report1.json,tslint-report2.json"
+            };
+
+            var builder = beginSettings.GetArguments(null);
+
+            var r = builder.Render();
+            var s = builder.RenderSafe();
+
+            Console.WriteLine($"Rendered: {r}");
+            Console.WriteLine($"Rendered Safe: {s}");
+
+            Assert.Equal(@"begin /d:sonar.host.url=""http://sonarqube.com:9000"" /d:sonar.typescript.tslint.reportPaths=""tslint-report1.json,tslint-report2.json"" /d:sonar.login=""tom"" /d:sonar.password=""god""", r);
+            Assert.Equal(@"begin /d:sonar.host.url=""http://sonarqube.com:9000"" /d:sonar.typescript.tslint.reportPaths=""tslint-report1.json,tslint-report2.json"" /d:sonar.login=""[REDACTED]"" /d:sonar.password=""[REDACTED]""", s);
+        }
+    }
+}

--- a/src/Cake.Sonar.Test/TypescriptCoverageArgumentBuilderTest.cs
+++ b/src/Cake.Sonar.Test/TypescriptCoverageArgumentBuilderTest.cs
@@ -6,7 +6,7 @@ namespace Cake.Sonar.Test
     public class TypescriptCoverageArgumentBuilderTest
     {
         [Fact]
-        public void CoverageExclussionsTest()
+        public void TypescriptCoverageTest()
         {
             var beginSettings = new SonarBeginSettings
             {

--- a/src/Cake.Sonar/SonarBeginSettings.cs
+++ b/src/Cake.Sonar/SonarBeginSettings.cs
@@ -149,6 +149,13 @@ namespace Cake.Sonar
         public string ResharperSolutionFile { get; set; }
 
         /// <summary>
+        /// This property accepts one or more JSON TSLint reports,
+        /// paths to report files should be absolute or relative to the project base directory.
+        /// </summary>
+        [Argument("/d:sonar.typescript.tslint.reportPaths=")]
+        public string TSLintReportPaths { get; set; }
+
+        /// <summary>
         /// Print verbose output during the analysis.
         /// </summary>
         public bool Verbose { get; set; }


### PR DESCRIPTION
This change provides an import into SonarQube of issues generated by TSLint. Closes #72.

Also small fixes in test naming.