### PR TITLE
Add pull request validation parameters to SonarBeginSettings

### DIFF
--- a/src/Cake.Sonar.Test/PullRequestArgumentTest.cs
+++ b/src/Cake.Sonar.Test/PullRequestArgumentTest.cs
@@ -1,0 +1,88 @@
+﻿using System;
+using Xunit;
+
+namespace Cake.Sonar.Test
+{
+	public class PullRequestArgumentTest
+	{
+		private readonly SonarBeginSettings _arguments;
+
+		public PullRequestArgumentTest()
+		{
+			_arguments = new SonarBeginSettings();
+		}
+
+		[Fact]
+		public void RenderedArguments_Do_Not_Contain_PullRequest_Arguments_If_Not_Set()
+		{
+			var argumentString = _arguments.GetArguments(null).Render();
+
+			Assert.DoesNotContain("sonar.pullrequest.provider", argumentString);
+			Assert.DoesNotContain("sonar.pullrequest.branch", argumentString);
+			Assert.DoesNotContain("sonar.pullrequest.key", argumentString);
+			Assert.DoesNotContain("sonar.pullrequest.base", argumentString);
+			Assert.DoesNotContain("sonar.pullrequest.github.repository", argumentString);
+			Assert.DoesNotContain("sonar.pullrequest.github.endpoint", argumentString);
+		}
+
+		[Fact]
+		public void Contains_The_PullRequest_Provider_If_Specified()
+		{
+			_arguments.PullRequestProvider = "vsts";
+
+			var argumentString = _arguments.GetArguments(null).Render();
+
+			Assert.Contains("sonar.pullrequest.provider=\"vsts\"", argumentString);
+		}
+
+		[Fact]
+		public void Contains_The_PullRequest_Branch_If_Specified()
+		{
+			_arguments.PullRequestBranch = "feature/some-feature-branch";
+
+			var argumentString = _arguments.GetArguments(null).Render();
+
+			Assert.Contains("sonar.pullrequest.branch=\"feature/some-feature-branch\"", argumentString);
+		}
+
+		[Fact]
+		public void Contains_The_PullRequest_Key_If_Specified()
+		{
+			_arguments.PullRequestKey = 1655;
+
+			var argumentString = _arguments.GetArguments(null).Render();
+
+			Assert.Contains("sonar.pullrequest.key=\"1655\"", argumentString);
+		}
+
+		[Fact]
+		public void Contains_The_PullRequest_Base_If_Specified()
+		{
+			_arguments.PullRequestBase = "master";
+
+			var argumentString = _arguments.GetArguments(null).Render();
+
+			Assert.Contains("sonar.pullrequest.base=\"master\"", argumentString);
+		}
+
+		[Fact]
+		public void Contains_The_PullRequest_GithubRepository_If_Specified()
+		{
+			_arguments.PullRequestGithubRepository = "my-company/my-repo";
+
+			var argumentString = _arguments.GetArguments(null).Render();
+
+			Assert.Contains("sonar.pullrequest.github.repository=\"my-company/my-repo\"", argumentString);
+		}
+
+		[Fact]
+		public void Contains_The_PullRequest_GithubEndpoint_If_Specified()
+		{
+			_arguments.PullRequestGithubEndpoint = "https://api.github.com";
+
+			var argumentString = _arguments.GetArguments(null).Render();
+
+			Assert.Contains("sonar.pullrequest.github.endpoint=\"https://api.github.com\"", argumentString);
+		}
+	}
+}

--- a/src/Cake.Sonar/SonarBeginSettings.cs
+++ b/src/Cake.Sonar/SonarBeginSettings.cs
@@ -161,6 +161,48 @@ namespace Cake.Sonar
         public string ResharperSolutionFile { get; set; }
 
         /// <summary>
+        /// Gets or sets the pull request provider used by sonarcloud. github or vsts.
+        /// See: https://docs.sonarqube.org/display/SONAR/Pull+Request+Analysis 
+        /// </summary>
+        [Argument("/d:sonar.pullrequest.provider=")]
+        public string PullRequestProvider { get; set; }
+
+        /// <summary>
+        /// Gets or sets the branch name in case of a pull request validation
+        /// See https://docs.sonarqube.org/display/SONAR/Pull+Request+Analysis
+        /// </summary>
+        [Argument("/d:sonar.pullrequest.branch=")]
+        public string PullRequestBranch { get; set; }
+
+        /// <summary>
+        /// Gets or sets the pullrequest key in case of a pull request validation
+        /// See https://docs.sonarqube.org/display/SONAR/Pull+Request+Analysis
+        /// </summary>
+        [Argument("/d:sonar.pullrequest.key=")]
+        public int? PullRequestKey { get; set; }
+
+        /// <summary>
+        /// Gets or sets the base branch in which the pull request will be merged in case of a pull request validation
+        /// See https://docs.sonarqube.org/display/SONAR/Pull+Request+Analysis
+        /// </summary>
+        [Argument("/d:sonar.pullrequest.base=")]
+        public string PullRequestBase { get; set; }
+
+        /// <summary>
+        /// Gets or sets the github endpoint url.
+        /// See: https://docs.sonarqube.org/display/SONAR/Pull+Request+Analysis 
+        /// </summary>
+        [Argument("/d:sonar.pullrequest.github.endpoint=")]
+        public string PullRequestGithubEndpoint { get; set; }
+
+        /// <summary>
+        /// Gets or sets the github repository for which the pull request should be validated. Typical github format CompanyOrUser/RepositoryName
+        /// See: https://docs.sonarqube.org/display/SONAR/Pull+Request+Analysis
+        /// </summary>
+        [Argument("/d:sonar.pullrequest.github.repository=")]
+        public string PullRequestGithubRepository { get; set; }
+
+        /// <summary>
         /// Print verbose output during the analysis.
         /// </summary>
         public bool Verbose { get; set; }


### PR DESCRIPTION
Add new pull request validation parameters for the SonarBeginSettings to be able to use the SonarQube PullRequest validation with TFS/VSTS and Github.

Added the settings according to the documentation page:
https://docs.sonarqube.org/display/SONAR/Pull+Request+Analysis