### PR TITLE
Add property to manually set the .NET Core Tool

### DIFF
--- a/src/Cake.Sonar.Test/Cake.Sonar.Test.csproj
+++ b/src/Cake.Sonar.Test/Cake.Sonar.Test.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
@@ -8,6 +8,8 @@
     <ProjectReference Include="..\Cake.Sonar\Cake.Sonar.csproj" />
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="Cake.Testing" Version="0.28.0" />
+    <PackageReference Include="Moq" Version="4.10.0" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="Cake.Common" Version="0.28.0" />
     <PackageReference Include="Cake.Core" Version="0.28.0" />

--- a/src/Cake.Sonar.Test/SonarRunnerTests.cs
+++ b/src/Cake.Sonar.Test/SonarRunnerTests.cs
@@ -1,0 +1,47 @@
+﻿using Cake.Core.Diagnostics;
+using Cake.Core.IO;
+using Cake.Core.Tooling;
+using Cake.Testing;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Cake.Sonar.Test
+{
+    public class SonarRunnerTests
+    {
+        private Mock<IToolLocator> _toolLocator;
+        private SonarRunner _runner;
+
+        public SonarRunnerTests()
+        {
+            var env = new FakeEnvironment(Core.PlatformFamily.Windows);
+            env.WorkingDirectory = System.IO.Directory.GetCurrentDirectory();
+            _toolLocator = new Mock<IToolLocator>();
+            _runner = new SonarRunner(new FakeLog(), new FakeFileSystem(env), env, new Mock<IProcessRunner>().Object, _toolLocator.Object);
+        }
+
+        [Fact]
+        public void Executes_CoreClr_Build_When_UseCoreClrSetting_IsSet()
+        {
+            var settings = new SonarBeginSettings
+            {
+                UseCoreClr = true
+            };
+
+            try
+            {
+                _runner.Run(settings);
+            }
+            catch
+            {
+                // We cannot mock FileSystemAccess in the internals of the SonarRunner 
+                // Let´s ignore IOExceptions, just verify that Resolve() was called with the expected (.NET Core tool) arguments
+            }
+
+            _toolLocator.Verify(t => t.Resolve(SonarRunner.CORECLR_TOOL_NAME));
+        }
+    }
+}

--- a/src/Cake.Sonar/SonarRunner.cs
+++ b/src/Cake.Sonar/SonarRunner.cs
@@ -45,7 +45,7 @@ namespace Cake.Sonar
             var arguments = settings.GetArguments(_environment);
             _log.Information(arguments.RenderSafe());
 
-			if(_environment.Runtime.IsCoreClr ) {
+			if(_environment.Runtime.IsCoreClr || settings.UseCoreClr) {
 				var tool = _toolsLocator.Resolve(CORECLR_TOOL_NAME);
 				if( tool == null ) {
 					throw new Exception($"No CoreCLR executable found ({CORECLR_TOOL_NAME})");

--- a/src/Cake.Sonar/SonarSettings.cs
+++ b/src/Cake.Sonar/SonarSettings.cs
@@ -24,6 +24,11 @@ namespace Cake.Sonar
         /// </summary>
         [Argument("/d:sonar.password=", Secure = true)]
         public string Password { get; set; }
+		
+		/// <summary>
+        /// Use .NET Core version of the SonarQube scanner in case of a .NET Core build.
+        /// </summary>
+        public bool UseCoreClr { get; set; }
 
         public abstract ProcessArgumentBuilder GetArguments(ICakeEnvironment environment);
 

--- a/src/Cake.Sonar/SonarSettings.cs
+++ b/src/Cake.Sonar/SonarSettings.cs
@@ -25,7 +25,7 @@ namespace Cake.Sonar
         [Argument("/d:sonar.password=", Secure = true)]
         public string Password { get; set; }
 		
-		/// <summary>
+        /// <summary>
         /// Use .NET Core version of the SonarQube scanner in case of a .NET Core build.
         /// </summary>
         public bool UseCoreClr { get; set; }


### PR DESCRIPTION
Added a new property to force SonarRunner to use the .NET Core tool. 

Fixing issue #79.