### PR TITLE
Add missing attribute for SonarEnd alias

### DIFF
--- a/src/Cake.Sonar/SonarCakeAliases.cs
+++ b/src/Cake.Sonar/SonarCakeAliases.cs
@@ -100,6 +100,7 @@ namespace Cake.Sonar
         /// </code>
         /// </example>
         /// <param name="context"></param>
+        [CakeMethodAlias]
         public static void SonarEnd(this ICakeContext context)
         {
             SonarEnd(context, new SonarEndSettings());


### PR DESCRIPTION
Add missing attribute to make the `SonarEnd` method available as an alias method.