### PR TITLE
Improve alias documentation

### DIFF
--- a/src/Cake.Sonar/SonarCakeAliases.cs
+++ b/src/Cake.Sonar/SonarCakeAliases.cs
@@ -40,7 +40,7 @@ namespace Cake.Sonar
     /// docker run -d --name sonarqube -p 9000:9000 -p 9092:9092 sonarqube
     /// </code>
     /// </example>
-    [CakeAliasCategory("Sonar")]
+    [CakeAliasCategory("SonarQube")]
     public static class SonarCakeAliases
     {
         /// <summary>
@@ -61,6 +61,7 @@ namespace Cake.Sonar
         /// <param name="context"></param>
         /// <param name="settings">A required settings object.</param>
         [CakeMethodAlias]
+        [CakeAliasCategory("SonarScanner for MSBuild")]
         public static void SonarBegin(this ICakeContext context, SonarBeginSettings settings)
         {
             GetRunner(context).Run(settings);
@@ -83,6 +84,7 @@ namespace Cake.Sonar
         /// <param name="context"></param>
         /// <param name="settings">A settings object containing credentials.</param>
         [CakeMethodAlias]
+        [CakeAliasCategory("SonarScanner for MSBuild")]
         public static void SonarEnd(this ICakeContext context, SonarEndSettings settings)
         {
             GetRunner(context).Run(settings);
@@ -100,6 +102,7 @@ namespace Cake.Sonar
         /// </code>
         /// </example>
         /// <param name="context"></param>
+        [CakeAliasCategory("SonarScanner for MSBuild")]
         public static void SonarEnd(this ICakeContext context)
         {
             SonarEnd(context, new SonarEndSettings());
@@ -124,6 +127,7 @@ namespace Cake.Sonar
         /// <param name="action"></param>
         /// <param name="settings"></param>
         [CakeMethodAlias]
+        [CakeAliasCategory("SonarScanner for MSBuild")]
         public static void Sonar(this ICakeContext context, Action<ICakeContext> action, SonarBeginSettings settings)
         {
             SonarBegin(context, settings);


### PR DESCRIPTION
Change alias category to `SonarQube` since this is the name of the product and allows to have documentation of aliases for this addin and the addin for the [SonarScanner](https://github.com/pitermarx/Cake.SonarScanner) on the same page once done the same change to both addins (see https://github.com/pitermarx/Cake.SonarScanner/pull/4).
Groups aliases from this addin under a `SonarScanner for MsBuild` category.